### PR TITLE
In Sitecore 9.0.1 Integration with Experience Editor doesn't work

### DIFF
--- a/Spe/App_Config/Include/Spe/Spe.config
+++ b/Spe/App_Config/Include/Spe/Spe.config
@@ -232,9 +232,13 @@
         <processor patch:before="processor[@type='Sitecore.Pipelines.GetContentEditorWarnings.RunRules, Sitecore.Kernel']"
            type="Spe.Core.Settings.Authorization.ContentEditorSecurityWarning, Spe" />
       </getContentEditorWarnings>
-      <getPageEditorNotifications>
-        <processor type="Spe.Integrations.Pipelines.PageEditorNotificationScript, Spe"/>
-      </getPageEditorNotifications>
+      <group groupName="ExperienceEditor" name="ExperienceEdiitor">
+       <pipelines>
+        <getPageEditorNotifications>
+          <processor type="Spe.Integrations.Pipelines.PageEditorNotificationScript, Spe"/>
+        </getPageEditorNotifications>
+       </pipelines>
+      <group>
       <getLookupSourceItems>
         <processor
           patch:before="*[@type='Sitecore.Pipelines.GetLookupSourceItems.ProcessQuerySource, Sitecore.Kernel']"


### PR DESCRIPTION
In Sitecore 9.0.1 getPageEditorNotifications are inside group tag, not directly inside <pipelines>